### PR TITLE
README.md typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ var utm=new utmObj('Everest');
 
 Convert from UTM to latitude/longitude coordinates.
 
-Returns `{ lat:xxxxx, lang:xxxxx }`.
+Returns `{ lat:xxxxx, lng:xxxxx }`.
 
 ### `utm.convertLatLngToUtm(latitude, longitude,precision);`
 


### PR DESCRIPTION
Just changed Returns `{ lat:xxxxx, lang:xxxxx }` to Returns `{ lat:xxxxx, lng:xxxxx }`